### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/build-and-publish-sdk.yml
+++ b/.github/workflows/build-and-publish-sdk.yml
@@ -2,7 +2,7 @@
 
 name: GitHub Actions - Tagged release
 on:
-  create:
+  push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 


### PR DESCRIPTION
As per actions/runner#1007 issue, tags filter is available for push event, not create