### PR TITLE
Do not exec javadoc for gradle build

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -28,4 +28,4 @@ jobs:
           java-version: '11'
           cache: 'gradle'
       - name: 'Build'
-        run: ./gradlew build --no-daemon
+        run: ./gradlew build -x dokkaJavadoc --no-daemon


### PR DESCRIPTION
build-sdk.yml workflow is a verification workflow, it isn't supposed to render javadoc/dokka files