### PR TITLE
Add initial support for multiple Payment providers

### DIFF
--- a/payments-contracts/src/main/kotlin/com/gevamu/corda/states/Payment.kt
+++ b/payments-contracts/src/main/kotlin/com/gevamu/corda/states/Payment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Exactpro Systems Limited
+ * Copyright 2022-2023 Exactpro Systems Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import java.util.UUID
  *
  * @param payer Corda party, which initiated payment
  * @param gateway Corda party, which processes payment
+ * @param paymentProviderId ID of payment provider, which processes payment
  * @param endToEndId Unique value for the payment in debtor-creditor scope
  * @param paymentInstructionId Link to payment instruction, stored as attachment. See [AttachmentId]
  * @param status Status of the payment in workflow
@@ -46,6 +47,7 @@ import java.util.UUID
 data class Payment(
     val payer: Party,
     val gateway: Party,
+    val paymentProviderId: UUID? = null,
     val endToEndId: String,
     val paymentInstructionId: AttachmentId,
     val status: PaymentStatus,
@@ -79,11 +81,10 @@ data class Payment(
      * Workflow:
      * 1. [CREATED]
      * 2. [SENT_TO_GATEWAY]
-     * 3. [PENDING]
-     * 4. [ACCEPTED] / [REJECTED]
+     * 3. [PENDING] / [ACCEPTED] / [REJECTED] / [COMPLETED]
      *
-     * If Accepted:
-     * 5. [COMPLETED]
+     * If [PENDING], [ACCEPTED]:
+     * N. [PENDING] / [ACCEPTED] / [REJECTED] / [COMPLETED]
      */
     @CordaSerializable
     enum class PaymentStatus {

--- a/payments-contracts/src/test/kotlin/com/gevamu/corda/test/contracts/AbstractPaymentContractTest.kt
+++ b/payments-contracts/src/test/kotlin/com/gevamu/corda/test/contracts/AbstractPaymentContractTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Exactpro Systems Limited
+ * Copyright 2022-2023 Exactpro Systems Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,4 +38,5 @@ abstract class AbstractPaymentContractTest {
     protected val uniquePaymentId: UUID = UUID.randomUUID()
     protected val attachmentId = SecureHash.SHA256(ByteArray(32))
     protected val endToEndId = "a1b2c3d4e5f6"
+    protected val paymentProviderId: UUID = UUID.randomUUID()
 }

--- a/payments-contracts/src/test/kotlin/com/gevamu/corda/test/contracts/PaymentContractCreateTest.kt
+++ b/payments-contracts/src/test/kotlin/com/gevamu/corda/test/contracts/PaymentContractCreateTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Exactpro Systems Limited
+ * Copyright 2022-2023 Exactpro Systems Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,31 @@ import com.gevamu.corda.contracts.PaymentContract
 import com.gevamu.corda.states.Payment
 import net.corda.testing.node.ledger
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 class PaymentContractCreateTest : AbstractPaymentContractTest() {
     @Test
     fun `should pass the valid transaction`() {
+        val outputPayment = Payment(
+            uniquePaymentId = uniquePaymentId,
+            payer = payer.party,
+            gateway = gateway.party,
+            paymentProviderId = UUID.randomUUID(),
+            endToEndId = endToEndId,
+            paymentInstructionId = attachmentId,
+            status = Payment.PaymentStatus.CREATED
+        )
+        ledgerServices.ledger {
+            transaction {
+                command(payer.publicKey, PaymentContract.Commands.Create(uniquePaymentId))
+                output(PaymentContract.ID, outputPayment)
+                verifies()
+            }
+        }
+    }
+
+    @Test
+    fun `should pass if paymentProviderId is not set`() {
         val outputPayment = Payment(
             uniquePaymentId = uniquePaymentId,
             payer = payer.party,

--- a/payments-workflows/src/main/kotlin/com/gevamu/corda/PaymentProviderInfo.kt
+++ b/payments-workflows/src/main/kotlin/com/gevamu/corda/PaymentProviderInfo.kt
@@ -1,0 +1,8 @@
+package com.gevamu.corda
+
+import net.corda.core.identity.Party
+import net.corda.core.serialization.CordaSerializable
+import java.util.UUID
+
+@CordaSerializable
+data class PaymentProviderInfo(val gatewayNode: Party, val providerId: UUID)

--- a/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/GetPaymentProvidersFlow.kt
+++ b/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/GetPaymentProvidersFlow.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2023 Exactpro Systems Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gevamu.corda.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import com.gevamu.corda.PaymentProviderInfo
+import net.corda.core.flows.FlowLogic
+import net.corda.core.flows.InitiatingFlow
+import net.corda.core.flows.StartableByService
+import net.corda.core.identity.Party
+import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.unwrap
+
+@CordaSerializable
+class GetPaymentProvidersResponse(val providers: List<PaymentProviderInfo>, val serial: Int)
+
+@InitiatingFlow
+@StartableByService
+class GetPaymentProvidersFlow(private val gateway: Party) : FlowLogic<List<PaymentProviderInfo>>() {
+    @Suspendable
+    override fun call(): List<PaymentProviderInfo> {
+        val gatewaySession = initiateFlow(gateway)
+        return gatewaySession
+            .receive(GetPaymentProvidersResponse::class.java, maySkipCheckpoint = true)
+            .unwrap { response ->
+                response.providers.onEach {
+                    require(it.javaClass == PaymentProviderInfo::class.java) {
+                        "Unexpected PaymentProviderInfo class: ${it.javaClass}"
+                    }
+                }
+            }
+    }
+}

--- a/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/PaymentFlow.kt
+++ b/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/PaymentFlow.kt
@@ -80,6 +80,7 @@ class PaymentFlow(
     private val paymentInstruction: PaymentInstruction,
     private val gateway: Party,
     private val uniquePaymentId: UUID = UUID.randomUUID(),
+    private val paymentProviderId: UUID? = null,
 ) : FlowLogic<List<StateAndRef<Payment>>>() {
 
     @Suspendable
@@ -102,6 +103,7 @@ class PaymentFlow(
             uniquePaymentId = uniquePaymentId,
             payer = ourIdentity,
             gateway = gateway,
+            paymentProviderId = paymentProviderId,
             paymentInstructionId = attachmentId,
             endToEndId = endToEndId,
             status = Payment.PaymentStatus.CREATED,

--- a/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/SendPaymentFlow.kt
+++ b/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/SendPaymentFlow.kt
@@ -31,9 +31,9 @@ import net.corda.core.node.services.queryBy
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.node.services.vault.builder
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.unwrap
 import java.time.Instant
 import java.util.UUID
-import net.corda.core.utilities.unwrap
 
 @InitiatingFlow
 @StartableByService

--- a/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/SendPaymentFlow.kt
+++ b/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/SendPaymentFlow.kt
@@ -33,13 +33,14 @@ import net.corda.core.node.services.vault.builder
 import net.corda.core.transactions.TransactionBuilder
 import java.time.Instant
 import java.util.UUID
+import net.corda.core.utilities.unwrap
 
 @InitiatingFlow
 @StartableByService
 class SendPaymentFlow(private val uniquePaymentId: UUID) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
-        logger.debug("Send payment id=$uniquePaymentId")
+        logger.debug("Send payment id={}", uniquePaymentId)
         val paymentStateAndRef = builder {
             // Find all active Payments for the given ID using its JPA entity
             val criteria = QueryCriteria.VaultCustomQueryCriteria(
@@ -54,18 +55,26 @@ class SendPaymentFlow(private val uniquePaymentId: UUID) : FlowLogic<Unit>() {
             //      and status is CREATED or add status to the query criteria
             serviceHub.vaultService.queryBy<Payment>(criteria).states.first()
         }
-        logger.debug("Found payment stateAndRef=$paymentStateAndRef")
+        logger.debug("Found payment stateAndRef={}", paymentStateAndRef)
+
+        val gateway = paymentStateAndRef.state.data.gateway
+
+        val gatewaySession: FlowSession = initiateFlow(gateway)
+
+        val defaultPaymentProvider: UUID = gatewaySession.receive(UUID::class.java).unwrap { it }
 
         // Mutate it to change status and timestamp
-        val payment = paymentStateAndRef.state.data.copy(
-            status = Payment.PaymentStatus.SENT_TO_GATEWAY,
-            timestamp = Instant.now(),
-        )
+        val payment = paymentStateAndRef.state.data.run {
+            copy(
+                status = Payment.PaymentStatus.SENT_TO_GATEWAY,
+                timestamp = Instant.now(),
+                paymentProviderId = if (paymentProviderId == null) defaultPaymentProvider else paymentProviderId
+            )
+        }
 
         // Prepare transaction to send over the state
         // TODO It's better to replace notary with named one since we are consuming states
         val notary = serviceHub.networkMapCache.notaryIdentities.first()
-        val gateway = paymentStateAndRef.state.data.gateway
         val builder = TransactionBuilder(notary)
             .addInputState(paymentStateAndRef)
             .addOutputState(payment)
@@ -73,12 +82,8 @@ class SendPaymentFlow(private val uniquePaymentId: UUID) : FlowLogic<Unit>() {
             .addAttachment(paymentStateAndRef.state.data.paymentInstructionId)
         builder.verify(serviceHub)
 
-        // Sign the transaction on our payer cordapp
+        // Sign the transaction on our side
         val partiallySignedTransaction = serviceHub.signInitialTransaction(builder)
-
-        // Notify gateway about incoming payment tx
-        val gatewaySession: FlowSession = initiateFlow(gateway)
-        logger.debug("initiateFlow(gateway)")
 
         // Expect gateway to sign the transaction
         val fullySignedTransaction = subFlow(CollectSignaturesFlow(partiallySignedTransaction, listOf(gatewaySession)))

--- a/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/StatusUpdateFlowResponder.kt
+++ b/payments-workflows/src/main/kotlin/com/gevamu/corda/flows/StatusUpdateFlowResponder.kt
@@ -27,7 +27,7 @@ import net.corda.core.transactions.SignedTransaction
 import net.corda.core.utilities.unwrap
 
 @InitiatedBy(StatusUpdateFlow::class)
-class StatusUpdateFlowResponder(val counterpartySession: FlowSession) : FlowLogic<Unit>() {
+class StatusUpdateFlowResponder(private val counterpartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val signedTransactionId = receiveAndSignTransaction()

--- a/payments-workflows/src/main/kotlin/com/gevamu/corda/services/PaymentsService.kt
+++ b/payments-workflows/src/main/kotlin/com/gevamu/corda/services/PaymentsService.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Exactpro Systems Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gevamu.corda.services
+
+import com.gevamu.corda.PaymentProviderInfo
+import net.corda.core.identity.Party
+import net.corda.core.node.AppServiceHub
+import net.corda.core.node.services.CordaService
+import net.corda.core.serialization.SingletonSerializeAsToken
+
+@CordaService
+class PaymentsService(private val serviceHub: AppServiceHub) : SingletonSerializeAsToken() {
+    fun getPaymentProviders(gateway: Party): List<PaymentProviderInfo> = emptyList()
+}


### PR DESCRIPTION
Add initial support for multiple Payment providers on a single Gateway node.